### PR TITLE
fix this.readConfig TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,18 +36,18 @@ module.exports = {
         },
         enableRevisionTagging: true,
 
-        didDeployMessage: function(/*context*/){
-          if (this.readConfig('renderRevisionKeyOnly')) {
+        didDeployMessage: function(context, pluginHelper){
+          if (pluginHelper.readConfig('renderRevisionKeyOnly')) {
             return false;
           }
           return "Uploaded sourcemaps to sentry release: "
-            + this.readConfig('sentryUrl')
+            + pluginHelper.readConfig('sentryUrl')
             + '/'
-            + this.readConfig('sentryOrganizationSlug')
+            + pluginHelper.readConfig('sentryOrganizationSlug')
             + '/'
-            + this.readConfig('sentryProjectSlug')
+            + pluginHelper.readConfig('sentryProjectSlug')
             + '/releases/'
-            + this.readConfig('revisionKey')
+            + pluginHelper.readConfig('revisionKey')
             + '/';
         },
         replaceFiles: true

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-deploy-plugin": "^0.2.0",
+    "ember-cli-deploy-plugin": "^0.2.9",
     "form-data": "^1.0.0-rc3",
     "glob": "^5.0.14",
     "request-promise": "^0.4.3",


### PR DESCRIPTION
Fixes: `TypeError: this.readConfig is not a function` when running `ember deploy`

@magicgrl111 